### PR TITLE
WIP: update for better database performance

### DIFF
--- a/src/Traits/Authorizable.php
+++ b/src/Traits/Authorizable.php
@@ -52,11 +52,11 @@ trait Authorizable
     public function hasRole($role)
     {
         if (is_string($role)) {
-            $role = $this->roles()->whereName($role)->first();
+            return $this->roles->contains('name', $role);
         }
 
         if ($role instanceof Model) {
-            return $this->roles()->find($role->getKey()) instanceof Model;
+            return $this->roles->find($role->getKey()) instanceof Model;
         }
 
         return false;
@@ -75,6 +75,8 @@ trait Authorizable
             $roles = collect($roles);
         }
 
+        $this->load('roles');
+
         return $roles->filter(function ($role) {
             return $this->hasRole($role);
         })->count() === $roles->count();
@@ -92,6 +94,8 @@ trait Authorizable
         if (! $roles instanceof Collection) {
             $roles = collect($roles);
         }
+
+        $this->load('roles');
 
         return $roles->filter(function ($role) {
             return $this->hasRole($role);


### PR DESCRIPTION
At the moment when asking if the user has a role/permission, for every permission you ask, it will make a query to the server.
Now that's fine for one or two, but if you ask for many you will get performance issues.

I have changed the code `hasAnyRole` and `hasRoles` so that it will load all the roles and thus only executing a single query.
This is simply done by adding `$this->load('roles')`
[Laravel Docs](https://laravel.com/docs/7.x/eloquent-relationships#eager-loading)

The only thing that is left, is applying it on the permissions as well.